### PR TITLE
Added special constructor and type for support dig groups

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,5 +1,7 @@
 package mserv
 
+import "go.uber.org/dig"
+
 // Server interface
 type Server interface {
 	Start()
@@ -38,4 +40,15 @@ func (ms *MultiServer) Stop() {
 			s.Stop()
 		}
 	}
+}
+
+// DigMultiServerParams inject dig providers with `group:"mserv"` tag
+type DigMultiServerParams struct {
+	dig.In
+	Servers []Server `group:"mserv"`
+}
+
+// NewByDig returns new multi server instance from incomming params
+func NewByDig(p DigMultiServerParams) Server {
+	return New(p.Servers...)
 }


### PR DESCRIPTION
usage example:

```go
type HTTPServerResult struct {
	dig.Out
	Server mserv.Server `group:"mserv"`
}

func NewPprofServer(v *viper.Viper) HTTPServerResult {
	return HTTPServerResult{
		Server: mserv.NewHTTPServer(time.Second, &http.Server{
			Addr:    "9080",
			Handler: http.DefaultServeMux,
		}),
	}
}

func main() {
  d := dig.New()

  d.Provide(mserv.NewByDig)
  d.Provide(NewPprofServer)

  dic.Invoke(func(m mserv.Server){
    m.Start() // pprof server injected
  })
}
```
